### PR TITLE
Rename Gradle Enterprise to Develocity

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# Gradle Enterprise Moderne integration
+# Develocity Moderne integration
 
-This is an example Gradle project that is used to demonstrate [Moderne](https://www.moderne.io/) executing [OpenRewrite](https://docs.openrewrite.org/) recipes to enable the [Gradle Enterprise Gradle plugin](https://docs.gradle.com/enterprise/gradle-plugin/).
+This is an example Gradle project that is used to demonstrate [Moderne](https://www.moderne.io/) executing [OpenRewrite](https://docs.openrewrite.org/) recipes to enable the [Develocity Gradle plugin](https://docs.gradle.com/enterprise/gradle-plugin/).
 
-See [blog post](https://todo).
+See [blog post](https://gradle.com/blog/develocity-global-implementation-best-practice-using-openrewrite-to-enable-develocity-project-integration-and-rollout-at-scale/).
 
 ## License
 
-The Gradle Enterprise Moderne integration project is open-source software released under the [Apache 2.0 License][apache-license].
+The Develocity Moderne integration project is open-source software released under the [Apache 2.0 License][apache-license].
 
 [apache-license]: https://www.apache.org/licenses/LICENSE-2.0.html
 [gradle-download]: https://gradle.org/install/


### PR DESCRIPTION
Rename Gradle Enterprise to Develocity before renaming the repository itself